### PR TITLE
Fix license field in package.json & update license headers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,8 @@
+# This is the list of Direct authors for copyright purposes.
+#
+# This does not necessarily list everyone who has contributed code, since in
+# some cases, their employer may be the copyright holder.  To see the full list
+# of contributors, see the revision history with git log.
+
+Google LLC
+and other contributors

--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-# Copyright 2018 Google Inc.
+# Copyright 2015 - present The Direct Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/app/css/icons.css
+++ b/app/css/icons.css
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2015 - present The Direct Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/css/style.css
+++ b/app/css/style.css
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2015 - present The Direct Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/ts/app.ts
+++ b/app/ts/app.ts
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2015 - present The Direct Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the 'License');
 // you may not use this file except in compliance with the License.

--- a/app/ts/baseCtrl.ts
+++ b/app/ts/baseCtrl.ts
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2015 - present The Direct Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the 'License');
 // you may not use this file except in compliance with the License.

--- a/app/ts/canvasDirectives.ts
+++ b/app/ts/canvasDirectives.ts
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2015 - present The Direct Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the 'License');
 // you may not use this file except in compliance with the License.

--- a/app/ts/filters.ts
+++ b/app/ts/filters.ts
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2015 - present The Direct Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the 'License');
 // you may not use this file except in compliance with the License.

--- a/app/ts/gapi.ts
+++ b/app/ts/gapi.ts
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2015 - present The Direct Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the 'License');
 // you may not use this file except in compliance with the License.

--- a/app/ts/groupCtrl.ts
+++ b/app/ts/groupCtrl.ts
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2015 - present The Direct Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the 'License');
 // you may not use this file except in compliance with the License.

--- a/app/ts/projectListService.ts
+++ b/app/ts/projectListService.ts
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2015 - present The Direct Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the 'License');
 // you may not use this file except in compliance with the License.

--- a/app/ts/sidebarCtrl.ts
+++ b/app/ts/sidebarCtrl.ts
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2015 - present The Direct Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the 'License');
 // you may not use this file except in compliance with the License.

--- a/app/ts/specCtrl.ts
+++ b/app/ts/specCtrl.ts
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2015 - present The Direct Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the 'License');
 // you may not use this file except in compliance with the License.

--- a/app/ts/specDirectives.ts
+++ b/app/ts/specDirectives.ts
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2015 - present The Direct Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the 'License');
 // you may not use this file except in compliance with the License.

--- a/app/ts/specResource.ts
+++ b/app/ts/specResource.ts
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2015 - present The Direct Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the 'License');
 // you may not use this file except in compliance with the License.

--- a/app/ts/specTabCtrl.ts
+++ b/app/ts/specTabCtrl.ts
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2015 - present The Direct Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the 'License');
 // you may not use this file except in compliance with the License.

--- a/app/ts/storageService.ts
+++ b/app/ts/storageService.ts
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2015 - present The Direct Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the 'License');
 // you may not use this file except in compliance with the License.

--- a/app/ts/userCtrl.ts
+++ b/app/ts/userCtrl.ts
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2015 - present The Direct Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the 'License');
 // you may not use this file except in compliance with the License.

--- a/cron.yaml
+++ b/cron.yaml
@@ -1,4 +1,4 @@
-# Copyright 2018 Google Inc.
+# Copyright 2015 - present The Direct Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/index.yaml
+++ b/index.yaml
@@ -1,4 +1,4 @@
-# Copyright 2018 Google Inc.
+# Copyright 2015 - present The Direct Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2018 Google Inc.
+# Copyright 2015 - present The Direct Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/models.py
+++ b/models.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Google Inc.
+# Copyright 2015 - present The Direct Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "url": "git+https://github.com/material-motion/direct.git"
   },
   "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "author": "The Direct Authors (see AUTHORS)",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/material-motion/direct/issues"
   },


### PR DESCRIPTION
I noticed the license field is incorrectly set to ISC, so I fixed it.

I also updated the license headers to match [the other Material Motion projects](https://github.com/material-motion/sublime/blob/develop/license.js.sublime-snippet).